### PR TITLE
Add minimum required Home Assistant version to manifest

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
     "name": "QR-Code Generator",
-    "render_readme": true
+    "render_readme": true,
+    "homeassistant": "2023.11.0b0"
 }


### PR DESCRIPTION
fixes #90 