### PR TITLE
Remove dependency for pillow

### DIFF
--- a/custom_components/qr_generator/manifest.json
+++ b/custom_components/qr_generator/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "calculated",
   "issue_tracker" : "https://github.com/DeerMaximum/QR-Code-Generator/issues",
   "loggers": ["qr_generator"],
-  "requirements": ["pyqrcode==1.2.1", "pypng==0.0.21", "pillow==11.2.1"],
+  "requirements": ["pyqrcode==1.2.1", "pypng==0.0.21"],
   "version" : "2.1.15"
 }


### PR DESCRIPTION
"Custom integrations should only include requirements that are not required by the Core requirements.txt." https://developers.home-assistant.io/docs/creating_integration_manifest#custom-integration-requirements